### PR TITLE
prioritize packager connectors before frogports by mixin

### DIFF
--- a/src/main/java/net/liukrast/repackaged/mixin/PackagerBlockEntityMixin.java
+++ b/src/main/java/net/liukrast/repackaged/mixin/PackagerBlockEntityMixin.java
@@ -1,0 +1,38 @@
+package net.liukrast.repackaged.mixin;
+
+import com.simibubi.create.content.logistics.packagePort.frogport.FrogportBlockEntity;
+import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
+
+import net.liukrast.repackaged.content.logistics.PackagerConnectorBlockEntity;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PackagerBlockEntity.class)
+public class PackagerBlockEntityMixin {
+
+    @Inject(method = "wakeTheFrogs", at = @At("HEAD"), cancellable = true)
+    private void wakeTheFrogs(CallbackInfo ci) {
+        PackagerBlockEntity packager = (PackagerBlockEntity) (Object) this;
+        if (!(packager.getLevel().getBlockEntity(packager.getBlockPos().relative(Direction.UP)) instanceof FrogportBlockEntity))
+            return;
+
+        for (Direction direction : Direction.values()) {
+            BlockEntity blockEntity = packager.getLevel().getBlockEntity(packager.getBlockPos().relative(direction));
+            if (!(blockEntity instanceof PackagerConnectorBlockEntity connector))
+                continue;
+            if (connector.getTargetContainer() != packager.inventory)
+                continue;
+
+            connector.sendToNext(packager.inventory);
+            if (packager.inventory.extractItem(0, 1, true).isEmpty()) {
+                ci.cancel();
+                return;
+            }
+        }
+    }
+}

--- a/src/main/resources/repackaged.mixins.json
+++ b/src/main/resources/repackaged.mixins.json
@@ -10,6 +10,7 @@
 	"CrafterUnpackingHandlerMixin",
 	"DefaultUnpackingHandlerMixin",
 	"PackageEntityMixin",
+	"PackagerBlockEntityMixin",
 	"PackagerBlockMixin"
   ],
   "client": [


### PR DESCRIPTION
Hi! Sorry to bother you.
First of all, I really love your mods. I tried using this one with the latest Create version and noticed that the Packager Connector does not work well together with the Frogport: when both can access the same Packager, the Frogport can take the package before the connector has a chance to handle it.
I made this PR to address that behavior by letting the Packager Connector take priority before the Frogport is triggered. I'm still not very experienced with Minecraft mod development, so this may not be the best approach, but I wanted to share the fix in case it is useful.
Please feel free to adjust or suggest a better implementation.